### PR TITLE
Remove online check

### DIFF
--- a/core/devices/state.js
+++ b/core/devices/state.js
@@ -1,18 +1,17 @@
 'use strict';
 const _ = require('lodash'),
   available = require('./available'),
-  blocked = require('./isBlocked'),
-  online = require('./online');
+  blocked = require('./isBlocked');
 
 exports = module.exports = () => available()
   .then(devices => new Promise((resolve, reject) => {
     (function next(i) {
       if (i < _.size(devices)) {
         const device = devices[i];
-        Promise.all([blocked(device.name), online(device.name)])
-          .then(([blocked, online]) => {
+        blocked(device.name)
+          .then(blocked => {
             device.blocked = blocked;
-            device.online = online;
+            device.online = true;
             next(i + 1);
           })
           .catch(reject);

--- a/core/wol/state.js
+++ b/core/wol/state.js
@@ -1,23 +1,5 @@
 'use strict';
 const _ = require('lodash'),
-  available = require('./available'),
-  devices = require('../devices'),
-  log = require('debug-logger')('core:wol:state');
+  available = require('./available');
 
-exports = module.exports = () => available()
-  .then(hosts => new Promise((resolve, reject) => {
-    log.debug(`collecting state on ${_.size(hosts)} hosts`);
-    (function next(i) {
-      if (i < _.size(hosts)) {
-        const host = hosts[i];
-        devices.online(host.hostname)
-          .then(online => {
-            host.online = online;
-            next(i + 1);
-          })
-          .catch(reject);
-      } else {
-        resolve(hosts);
-      }
-    }(0));
-  }));
+exports = module.exports = () => available().then(devices => _.map(devices, d => _.set(d, 'online', false)));

--- a/routes/devices/online.js
+++ b/routes/devices/online.js
@@ -1,0 +1,14 @@
+'use strict';
+const _ = require('lodash'),
+  HttpError = require('http-error-constructor'),
+  core = require('../../core');
+
+exports = module.exports = (req, res, next) => {
+  const hostname = _.get(req.query, 'hostname');
+  if (!hostname) {
+    return Promise.resolve(next(new HttpError(400, 'missing hostname parameter')));
+  }
+  return core.devices.online(hostname)
+    .then(online => res.json({hostname, online}))
+    .catch(next);
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,6 +8,7 @@ const router = require('express').Router(),
   wolState = require('./wol/state'),
   serviceState = require('./services/state'),
   deviceState = require('./devices/state'),
+  onlineState = require('./devices/online'),
   jwtVerify = require('../middleware/jwtVerify')(env.jwtKey());
 
 router.get('/auth', auth);
@@ -17,5 +18,6 @@ router.use('/wol', jwtVerify, wol);
 router.get('/services/state', serviceState);
 router.use('/services', jwtVerify, services);
 router.get('/devices/state', deviceState);
+router.get('/devices/online', onlineState);
 
 exports = module.exports = router;


### PR DESCRIPTION
Fixes #41

Including online check in state made things horrendous for UX.
For now, faking online status for the sake of minimal change to UI (none).

Added new REST endpoint to check real online status:

```
GET /api/devices/online?hostname={}
```

Returns a JSON object:
```
{
  "hostname": string,
  "online": boolean
}
```